### PR TITLE
setDefaultOptions is deprecated

### DIFF
--- a/Form/Type/TagType.php
+++ b/Form/Type/TagType.php
@@ -34,7 +34,7 @@ class TagType extends AbstractType
         ;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => $this->tagClass


### PR DESCRIPTION
In Symfony 2.7, the setDefaultOptions() method of AbstractType and AbstractExtensionType has been deprecated in favor of the new configureOptions() method
