### PR TITLE
setDefaults Is deprecated

### DIFF
--- a/Form/Type/TagType.php
+++ b/Form/Type/TagType.php
@@ -34,7 +34,7 @@ class TagType extends AbstractType
         ;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => $this->tagClass

--- a/Form/Type/TagsType.php
+++ b/Form/Type/TagsType.php
@@ -125,7 +125,7 @@ class TagsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setOptional(array(
             'autocomplete', // type of autocomplete

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 anh_taggable_search:
-    pattern:  /_taggable/search.json
+    path:  /_taggable/search.json
     defaults: { _controller: AnhTaggableBundle:Default:search }


### PR DESCRIPTION
In Symfony 2.7, the setDefaultOptions() method of AbstractType and AbstractExtensionType has been deprecated in favor of the new configureOptions() method:

http://symfony.com/blog/new-in-symfony-2-7-form-and-validator-updates
